### PR TITLE
Bugfix: no response from dkg/search causing Annotate Dataset page to crash

### DIFF
--- a/ui/client/datasets/annotations/OntologiesSelector.js
+++ b/ui/client/datasets/annotations/OntologiesSelector.js
@@ -130,7 +130,7 @@ export default withStyles((theme) => ({
           )}
           <div className={classes.ontologiesBox}>
             <List className={classes.list}>
-              {searchResults?.map((result) => (
+              {searchResults.length && searchResults?.map((result) => (
                 <ListItem
                   classes={{ root: classes.listItem }}
                   key={result.id}


### PR DESCRIPTION
This PR fixes a bug where no response from the dkg/search endpoint would cause the entire Annotate Dataset page to crash when the Add Ontology Term button was clicked. 

This fix is also in https://github.com/DARPA-ASKEM/data-annotation/pull/12, but I wanted to break it out into its own PR as we might not be merging that for a while. 