### PR TITLE
Fix data paths in mixmasta processor

### DIFF
--- a/tasks/tasks/mixmasta_processors.py
+++ b/tasks/tasks/mixmasta_processors.py
@@ -144,7 +144,7 @@ def run_mixmasta(context, filename=None):
             if dest_file_path.startswith("s3:"):
                 location_info = urlparse(dest_file_path)
                 data_files.append(
-                    f"s3://{location_info.netloc}/{location_info.path}"
+                    f"s3://{location_info.netloc}{location_info.path}"
                 )
             else:
                 data_files.append(dest_file_path)


### PR DESCRIPTION
Super simple fix to make sure the produced `data_paths` are correct. 

@mattprintz @Sorrento110 @fivegrant is there some case where this won't work right? 

I know it will work OK for a path like `s3://askem-prod-data-service/datasets` 😄 